### PR TITLE
enable OLD CMP0148 to allow FindPythonInterp on cmake 3.27+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
+if(POLICY CMP0148)
+  #enable FindPythonInterp
+  cmake_policy(SET CMP0148 OLD)
+endif()
+
 if(NOT DEFINED LLVM_VERSION_MAJOR)
   set(LLVM_VERSION_MAJOR 9)
 endif()


### PR DESCRIPTION
This resolves a cmake failure on platforms with cmake 3.27+, and, I believe no `python` executable (just a `python3`).

https://cmake.org/cmake/help/latest/module/FindPythonInterp.html