### PR TITLE
migrate to `find_package(Python)` for cmake 3.27+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -641,17 +641,11 @@ option(LLVM_ENABLE_PLUGINS "Enable plugin support" ${LLVM_ENABLE_PLUGINS_default
 
 include(HandleLLVMOptions)
 
-include(FindPythonInterp)
-if( NOT PYTHONINTERP_FOUND )
-  message(FATAL_ERROR
-"Unable to find Python interpreter, required for builds and testing.
-
-Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
-endif()
-
-if( ${PYTHON_VERSION_STRING} VERSION_LESS 2.7 )
+find_package(Python COMPONENTS Interpreter REQUIRED)
+if(Python_VERSION VERSION_LESS 2.7)
   message(FATAL_ERROR "Python 2.7 or newer is required")
 endif()
+set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
 
 ######
 # LLVMBuild Integration


### PR DESCRIPTION
`FindPythonInterp` has been deprecated for a long time; it's removed in 3.27+ unless an old policy is forced (which I had trouble with doing in a previous PR..). It's easy enough to refactor this to use `find_package(Python)` though, so let's go that approach